### PR TITLE
Add RegisteredFunction type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PROJECT=registry
 PY_VER=python3.10
 PY_VER_SHORT=py$(shell echo $(PY_VER) | sed 's/[^0-9]*//g')
-QUALITY_DIRS=$(PROJECT) tests setup.py
+QUALITY_DIRS=$(PROJECT) tests setup.py example.py
 CLEAN_DIRS=$(PROJECT) tests
 VENV=$(shell pwd)/env
 PYTHON=$(VENV)/bin/python
@@ -25,6 +25,7 @@ clean: ## remove cache files
 	find $(CLEAN_DIRS) -name '*@neomake*' -type f -delete
 	find $(CLEAN_DIRS) -name '*.pyc' -type f -delete
 	find $(CLEAN_DIRS) -name '*,cover' -type f -delete
+	find $(CLEAN_DIRS) -name '*.orig' -type f -delete
 
 clean-env: ## remove the virtual environment directory
 	rm -rf $(VENV)

--- a/example.py
+++ b/example.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+from registry import Registry
+
+
+STRING_REGISTRY = Registry("string", bound=Callable[[str], str])
+
+
+@STRING_REGISTRY(name="strip")
+def strip(x: str) -> str:
+    return x.strip()
+
+
+@STRING_REGISTRY(name="getword-0", index=0)
+@STRING_REGISTRY(name="getword-1", index=1)
+@dataclass
+class GetWord:
+    index: int = 0
+
+    def __call__(self, x: str, **kwargs) -> str:
+        return x.split(" ")[self.index]
+
+
+def to_upper(x: str) -> str:
+    return x.upper()
+
+
+lines = [
+    " nuke the site from orbit...",
+    "only way to be sure ",
+]
+
+
+pipeline = ["strip", "getword-1", to_upper]
+
+
+output_lines: List[str] = []
+for line in lines:
+    for step in pipeline:
+        fn = STRING_REGISTRY.get(step).instantiate_with_metadata()
+        line = fn(line)
+    output_lines.append(line)
+
+# should output ["THE", "WAY"]
+print(output_lines)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             }
         },
         "node_modules/pyright": {
-            "version": "1.1.128",
-            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.128.tgz",
-            "integrity": "sha512-p+QG3W+PEQs6raeix/oIBU/eKRL487WftEFI3PVR7npF/2fzh6v4ucNjlF/jPAfP1x/ulInqeyeqvwLwvajTwA==",
+            "version": "1.1.258",
+            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.258.tgz",
+            "integrity": "sha512-UqWgefteEenCw3Npm65vktRpz5IGtD75xMB0gz8vNVqdIEcggMChrSbDpOSfEHhL6D5wEWPG5fpuvNHiMxi1oA==",
             "bin": {
                 "pyright": "index.js",
                 "pyright-langserver": "langserver.index.js"
@@ -23,9 +23,9 @@
     },
     "dependencies": {
         "pyright": {
-            "version": "1.1.128",
-            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.128.tgz",
-            "integrity": "sha512-p+QG3W+PEQs6raeix/oIBU/eKRL487WftEFI3PVR7npF/2fzh6v4ucNjlF/jPAfP1x/ulInqeyeqvwLwvajTwA=="
+            "version": "1.1.258",
+            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.258.tgz",
+            "integrity": "sha512-UqWgefteEenCw3Npm65vktRpz5IGtD75xMB0gz8vNVqdIEcggMChrSbDpOSfEHhL6D5wEWPG5fpuvNHiMxi1oA=="
         }
     }
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,5 @@
 {
 	"venvPath": ".",
-	"venv": "env"
+	"venv": "env",
+  "pythonVersion": "3.11"
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-	"venvPath": ".",
-	"venv": "env",
+  "venvPath": ".",
+  "venv": "env",
   "pythonVersion": "3.11"
 }

--- a/registry/__init__.py
+++ b/registry/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from .registry import RegisteredFunction, Registry
+from .registry import RegisteredFunction, Registry, bind_relevant_kwargs, has_var_kwargs, iterate_arg_names
 
 
 try:
@@ -8,4 +8,4 @@ try:
 except ImportError:
     __version__ = "Unknown"
 
-__all__ = ["Registry", "RegisteredFunction"]
+__all__ = ["Registry", "RegisteredFunction", "iterate_arg_names", "has_var_kwargs", "bind_relevant_kwargs"]


### PR DESCRIPTION
The existing pattern of using a registry to return a callable has a few disadvantages:
1. It is difficult to manage a mix of callables and callable classes which must be instantiated prior to being called, such as callable dataclasses
2. No out of box support exists for passing relevant keyword args to a retrieved registered function.
3. Forwarding keyword args from registered metadata requires boilerplate code. The metadata must be retrieved and then manually passed to the retrieved method.

This PR addresses these limitations by adding a `RegisteredFunction` wrapper dataclass for callables returned from a registry. The advantages are:
* Access to metadata is provided through an attribute, eliminating the need for a separate `get_with_metadata` method
* Instantiation can be performed for callable classes without causing errors for standard functions
* Keyword args can be selectively forwarded to a callable based on the callable's signature
* `RegisteredFunction` is itself callable, and will call the underlying member callable